### PR TITLE
minor changes to support version 2.8.1

### DIFF
--- a/lib/src/Modules/visibility_detector/visibility_detector_layer.dart
+++ b/lib/src/Modules/visibility_detector/visibility_detector_layer.dart
@@ -269,11 +269,13 @@ class VisibilityDetectorLayer extends ContainerLayer {
   }
 
   /// See [Layer.addToScene].
+  // Left the offset argument for backward compatibility
   @override
   void addToScene(ui.SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
     _layerOffset = layerOffset;
     _scheduleUpdate();
-    super.addToScene(builder, layerOffset);
+    // Flutter removed offset argument as of version 2.8.1
+    super.addToScene(builder);
   }
 
   /// See [AbstractNode.attach].


### PR DESCRIPTION
It seems flutter 2.8.1 discontinued having an optional offset argument for addToScene method of the ContainerLayer class.

I don't know how this would affect your code base but it solved my issue.